### PR TITLE
Add DigitalElevationMapUpdate message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,13 @@ find_package(std_msgs)
 find_package(nav_msgs)
 find_package(rosidl_default_generators REQUIRED)
 
-rosidl_generate_interfaces(${PROJECT_NAME} "msg/DigitalElevationMap.msg" "msg/DigitalElevationMapUpdate.msg" DEPENDENCIES std_msgs nav_msgs)
+rosidl_generate_interfaces(
+  ${PROJECT_NAME}
+  "msg/DigitalElevationMap.msg"
+  "msg/DigitalElevationMapUpdate.msg"
+  DEPENDENCIES
+  std_msgs
+  nav_msgs
+)
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,6 @@ find_package(std_msgs)
 find_package(nav_msgs)
 find_package(rosidl_default_generators REQUIRED)
 
-rosidl_generate_interfaces(${PROJECT_NAME} "msg/DigitalElevationMap.msg" DEPENDENCIES std_msgs nav_msgs)
+rosidl_generate_interfaces(${PROJECT_NAME} "msg/DigitalElevationMap.msg" "msg/DigitalElevationMapUpdate.msg" DEPENDENCIES std_msgs nav_msgs)
 
 ament_package()

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 This package provides custom messages to represent Digital Elevation Map (DEM).
 
-It is based on [nav_msgs/OccupancyGrid](https://github.com/ros2/common_interfaces/blob/iron/nav_msgs/msg/OccupancyGrid.msg)
+It is based on [nav_msgs/OccupancyGrid](https://github.com/ros2/common_interfaces/blob/iron/nav_msgs/msg/OccupancyGrid.msg) and [map_msgs/OccupancyGridUpdate](https://github.com/ros-planning/navigation_msgs/blob/rolling/map_msgs/msg/OccupancyGridUpdate.msg)
 
 ## Messages (.msg)
 * [DigitalElevationMap](msg/DigitalElevationMap.msg): An array of cells in a 2D grid, each cell represents the height associated to the (x, y) location.
+* [DigitalElevationMapUpdate](msg/DigitalElevationMapUpdate.msg): The corresponding partial update message.

--- a/msg/DigitalElevationMapUpdate.msg
+++ b/msg/DigitalElevationMapUpdate.msg
@@ -1,0 +1,6 @@
+std_msgs/Header header
+int32 x
+int32 y
+uint32 width
+uint32 height
+float32[] data


### PR DESCRIPTION
Solving issue  #1.
This message provides information about changes made to a DEM map compared to its previous version. To reduce the amount of data, it transmits only these changes made to the map.